### PR TITLE
Add license link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This document contains everything you need in order to contribute to our project
 ## Code of Conduct
 You can access our code of conduct [here - add link to our code of conduct](). 
 
-Note: This project comes under the [MIT license. - add link to our license file]() 
+Note: This project comes under the [MIT license](https://github.com/mercury-telemetry/mercury-telemetry/blob/master/LICENSE.txt)
 
 ## Reporting Bugs
 This section guides you through reporting an issue. Following these guidelines will help maintainers to understand your issue and in case you are reporting a bug, reproduce the behavior.


### PR DESCRIPTION
Add missing link to project license in CONTRIBUTING.md

## Types of Changes
_Put an `x` in the boxes that apply_

- [ ] Feature (non-breaking change which adds functionality)
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] Breaking Change (feature/fix that causes existing features to not work as expected)
- [X] Documentation

## Checklist

- [x] I have read the [contribute]contributing<link> doc
- [x] Classes, scripts, and environment variables follow existing naming convention
- [x] Lint and Unit tests pass locally
- [x] New features on hardware have been tested on a local Raspberry Pi
- [x] Mention new programs/binaries if any must be installed along with this change
- [x] Mention new environment variables if any have been added to hardware/env file
- [x] Please make sure test coverage does not drop. If it does, please explain the reasons.
- [x] Any new required python modules are added to the requirements.txt