### PR TITLE
Readme and Setup script update

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,18 @@ python manage.py test
 
 Refer to our contributing guidelines [here.](https://github.com/mercury-telemetry/mercury-telemetry/blob/master/CONTRIBUTING.md)
 
-# Fix issues
-Running into issues with modules not find? Did `requirements.txt` update from your last `git pull` command? Run `pip install -r requirements.txt` to install missing modules.
+# F.A.Q.
+* Running into issue with modules not find?
 
-Are you missing staticfiles when trying to run or test locally? Run `python manage.py collectstatic` to regenerate them.
+    Run `git pull` to fetch latest update of `requirements.txt`. Then run `pip install -r requirements.txt` to install missing modules.
+
+* Missing staticfiles when running or testing locally?
+
+    Run `python manage.py collectstatic` to regenerate them.
+
+* Deploying to Heroku with `setting.DATABASES is improperly configured` error?
+
+    Make sure your (Heroku-Postgres)[https://elements.heroku.com/addons/heroku-postgresql] add-on is installed.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,6 @@ Refer to our contributing guidelines [here.](https://github.com/mercury-telemetr
 
     Run `python manage.py collectstatic` to regenerate them.
 
-* Deploying to Heroku with `setting.DATABASES is improperly configured` error?
-
-    Make sure your (Heroku-Postgres)[https://elements.heroku.com/addons/heroku-postgresql] add-on is installed.
-
 # License
 
 Copyright (c) Mercury Telemetry. All rights reserved.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -57,6 +57,10 @@ else
     esac
 fi
 
+# Install wheel first to avoid issue 
+# https://stackoverflow.com/questions/34819221/why-is-python-setup-py-saying-invalid-command-bdist-wheel-on-travis-ci
+pip3 install wheel
+
 echo ""
 __system "Running pip3 install -r requirements.txt..."
 pip3 install -r requirements.txt || exit 1


### PR DESCRIPTION
## Title
This PR: 
Turn "Fix Issues" into an FAQ
Fix running setup script error in Ubuntu 

## Description
1. Original fix issues section looks like the beginning of an installation FAQ, now changing the title to FAQ and adding FAQ template into this part.
2. When running `setup.sh` in a fresh Ubuntu environment, we will encounter '`Failed building wheel for psycopg2` in `pip3 install -r requirements.txt` part. The standard solution of adding wheel into requirements.txt doesn't work because this error is happening at pip install's collecting module stage, so I add that command `pip3 install wheel` before `pip3 install -r requirements.txt` in the `setup.sh`.



## Types of Changes
- [ ] Feature (non-breaking change which adds functionality)
- [x] Bug Fix (non-breaking change that fixes an issue)
- [ ] Breaking Change (feature/fix that causes existing features to not work as expected)
- [x] Documentation

## Checklist

- [x] I have read the [contribute]contributing<link> doc
- [x] Classes, scripts, and environment variables follow existing naming convention
- [x] Lint and Unit tests pass locally
- [x] New features on hardware have been tested on a local Raspberry Pi
- [x] Mention new programs/binaries if any must be installed along with this change
- [x] Mention new environment variables if any have been added to hardware/env file
- [x] Please make sure test coverage does not drop. If it does, please explain the reasons.
- [x] Any new required python modules are added to the requirements.txt